### PR TITLE
Enable more Dialyzer checks

### DIFF
--- a/lib/mdns_lite.ex
+++ b/lib/mdns_lite.ex
@@ -95,12 +95,12 @@ defmodule MdnsLite do
   def handle_call({:start_mdns_server, ifname}, _from, state) do
     with {:ok, server_pid} <-
            MdnsLite.Server.start({ifname, state.mdns_config, state.mdns_services}) do
-      Logger.debug("Start mdns server: server_pid #{inspect(server_pid)}")
+      _ = Logger.debug("Start mdns server: server_pid #{inspect(server_pid)}")
       new_ifname_server_map = Map.put(state.ifname_server_map, ifname, server_pid)
       {:reply, :ok, %State{state | ifname_server_map: new_ifname_server_map}}
     else
       {:error, reason} ->
-        Logger.debug("Start mdns server: #{inspect(reason)}")
+        _ = Logger.error("Starting mdns server failed: #{inspect(reason)}")
         {:reply, :ok, state}
     end
   end

--- a/lib/mdns_lite/server.ex
+++ b/lib/mdns_lite/server.ex
@@ -42,7 +42,7 @@ defmodule MdnsLite.Server do
   ##############################################################################
   #   Public interface
   ##############################################################################
-  @spec start(tuple()) :: GenServer.on_start()
+  @spec start({String.t(), map(), [map()]}) :: GenServer.on_start()
   def start({_ifname, _mdns_config, _mdns_services} = opts) do
     GenServer.start(__MODULE__, opts)
   end
@@ -88,7 +88,7 @@ defmodule MdnsLite.Server do
        }}
     else
       {:error, reason} ->
-        Logger.error("reason: #{inspect(reason)}")
+        _ = Logger.error("reason: #{inspect(reason)}")
         {:stop, reason}
     end
   end
@@ -171,7 +171,7 @@ defmodule MdnsLite.Server do
   defp send_response(dns_resource_records, dns_record, state) do
     # Construct a DNS record from the query plus answers (resource records)
     packet = response_packet(dns_record.header.id, dns_record.qdlist, dns_resource_records)
-    Logger.debug("Sending DNS response packet\n#{inspect(packet)}")
+    _ = Logger.debug("Sending DNS response packet\n#{inspect(packet)}")
     dns_record = DNS.Record.encode(packet)
     :gen_udp.send(state.udp, @mdns_ipv4, @mdns_port, dns_record)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -13,6 +13,9 @@ defmodule MdnsLite.MixProject do
       docs: docs(),
       description: description(),
       package: package(),
+      dialyzer: [
+        flags: [:unmatched_returns, :error_handling, :race_conditions, :underspecs]
+      ],
       deps: deps()
     ]
   end


### PR DESCRIPTION
The default set of checks is pretty minimal. This enables more and fixes
the new warnings. There weren't any issues.