### PR TITLE
Remove query from response per RFC 6762

### DIFF
--- a/lib/mdns_lite/server.ex
+++ b/lib/mdns_lite/server.ex
@@ -136,7 +136,7 @@ defmodule MdnsLite.Server do
   #   Private functions
   ##############################################################################
   # A standard mDNS response packet
-  defp response_packet(id, query_list, answer_list),
+  defp response_packet(id, answer_list),
     do: %DNS.Record{
       header: %DNS.Header{
         id: id,
@@ -145,8 +145,8 @@ defmodule MdnsLite.Server do
         opcode: 0,
         rcode: 0
       },
-      # The original queries
-      qdlist: query_list,
+      # Query list. Must be empty according to RFC 6762 Section 6.
+      qdlist: [],
       # A list of answer entries. Can be empty.
       anlist: answer_list,
       # A list of resource entries. Can be empty.
@@ -177,8 +177,8 @@ defmodule MdnsLite.Server do
   defp send_response([], _dns_record, _dest, _state), do: :ok
 
   defp send_response(dns_resource_records, dns_record, {dest_address, dest_port}, state) do
-    # Construct a DNS record from the query plus answers (resource records)
-    packet = response_packet(dns_record.header.id, dns_record.qdlist, dns_resource_records)
+    # Construct an mDNS response from the query plus answers (resource records)
+    packet = response_packet(dns_record.header.id, dns_resource_records)
 
     _ = Logger.debug("Sending DNS response to #{inspect(dest_address)}/#{inspect(dest_port)}")
     _ = Logger.debug("#{inspect(packet)}")


### PR DESCRIPTION
This is intended to be merged after #8 so that the only commit is the final one:

Remove query from response per RFC 6762

Section 6 says:

   Multicast DNS responses MUST NOT contain any questions in the
   Question Section.  Any questions in the Question Section of a
   received Multicast DNS response MUST be silently ignored.  Multicast
   DNS queriers receiving Multicast DNS responses do not care what
   question elicited the response; they care only that the information
   in the response is true and accurate.

This fixes an issue where mDNS worked when queried from OSX, but didn't
work when queried from Linux (presumably not all versions of Linux).