### PR TITLE
Remove domain field in mdns_config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -7,7 +7,6 @@ config :mdns_lite,
   # to a DNS query.
   mdns_config: %{
     host: :hostname,
-    domain: "local",
     ttl: 3600,
     query_types: [
       # IP address lookup,

--- a/lib/mdns_lite.ex
+++ b/lib/mdns_lite.ex
@@ -1,6 +1,6 @@
 defmodule MdnsLite do
   @moduledoc """
-  A simple implementation of an mDNS (multicast DNS (Domain Name Server)) server. 
+  A simple implementation of an mDNS (multicast DNS (Domain Name Server)) server.
   Rather than accessing a DNS server directly, mDNS
   is based on multicast UDP. Hosts/services listen on a well-known ip address/port. If
   a request arrives that the service can answer, it constructs the approriate DNS response.
@@ -32,7 +32,6 @@ defmodule MdnsLite do
 
   @default_config %{
     host: :hostname,
-    domain: "local",
     ttl: 3600,
     query_types: [:a, :ptr, :srv]
   }

--- a/lib/mdns_lite/server.ex
+++ b/lib/mdns_lite/server.ex
@@ -70,7 +70,7 @@ defmodule MdnsLite.Server do
     # We need the IP address for this network interface
     with {:ok, ip_tuple} <- ifname_to_ip(ifname) do
       discovery_name = resolve_mdns_name(mdns_config.host)
-      dot_local_name = discovery_name <> "." <> mdns_config.domain
+      dot_local_name = discovery_name <> ".local"
       # Join the mDNS multicast group
       {:ok, udp} = :gen_udp.open(@mdns_port, udp_options(ip_tuple))
 


### PR DESCRIPTION
Remove domain as a mdns_config field. The domain name is always ".local" 