### PR TITLE
Remove user-specified query_types to support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,7 @@ These implementations provided valuable guidance in the building of MdnsLite.
 
 ## Configuration
 
-MDNSLite can be configured to recognize all or a subset of the
-mDNS query types listed above. Note that
-listing the service doesn't guarantee the existence of that service.
+Note that listing the service doesn't guarantee the existence of that service.
 
 ```elixir
 config :mdns_lite,
@@ -35,15 +33,7 @@ config :mdns_lite,
   mdns_config: %{
     host: :hostname,
     domain: "local",
-    ttl: 3600,
-    query_types: [
-      # IP address lookup,
-      :a,
-      # Reverse IP lookup
-      :ptr,
-      # Services - see below
-      :srv
-    ]
+    ttl: 3600
   },
   services: [
     # service type: _http._tcp.local - used in match

--- a/config/config.exs
+++ b/config/config.exs
@@ -7,15 +7,7 @@ config :mdns_lite,
   # to a DNS query.
   mdns_config: %{
     host: :hostname,
-    ttl: 3600,
-    query_types: [
-      # IP address lookup,
-      :a,
-      # Reverse IP lookup
-      :ptr,
-      # Services - see below
-      :srv
-    ]
+    ttl: 3600
   },
   services: [
     # service type: _http._tcp - used in match

--- a/lib/mdns_lite.ex
+++ b/lib/mdns_lite.ex
@@ -32,8 +32,7 @@ defmodule MdnsLite do
 
   @default_config %{
     host: :hostname,
-    ttl: 3600,
-    query_types: [:a, :ptr, :srv]
+    ttl: 3600
   }
 
   defmodule State do

--- a/lib/mdns_lite/server.ex
+++ b/lib/mdns_lite/server.ex
@@ -30,7 +30,6 @@ defmodule MdnsLite.Server do
   defmodule State do
     @type t() :: struct()
     defstruct ifname: nil,
-              query_types: [],
               services: [],
               # Note: Erlang string
               dot_local_name: '',
@@ -76,8 +75,6 @@ defmodule MdnsLite.Server do
 
       {:ok,
        %State{
-         # A list of query types that we'll respond to.
-         query_types: mdns_config.query_types,
          # A list of services with types that we'll match against
          services: mdns_services,
          ifname: ifname,
@@ -157,7 +154,6 @@ defmodule MdnsLite.Server do
     # There can be multiple questions in a query. And it must be one of the
     # query types specified in the configuration
     dns_record.qdlist
-    |> Enum.filter(fn q -> q.type in state.query_types end)
     |> Enum.each(fn %DNS.Query{} = query ->
       responses = Query.handle(query, state)
       send_response(responses, dns_record, dest, state)

--- a/test/mdns_lite/query_test.exs
+++ b/test/mdns_lite/query_test.exs
@@ -10,7 +10,6 @@ defmodule MdnsLite.QueryTest do
       dot_local_name: 'nerves-21a5.local',
       ifname: "eth0",
       ip: {192, 168, 9, 57},
-      query_types: [:a, :ptr, :srv],
       services: [
         %{
           name: "Web Server",


### PR DESCRIPTION
This library supports everything it knows about and the user can't stop
us.