### PR TITLE
Rename MdnsLite.Server -> MdnsLite.Responder

### DIFF
--- a/lib/mdns_lite.ex
+++ b/lib/mdns_lite.ex
@@ -92,7 +92,7 @@ defmodule MdnsLite do
   @impl true
   def handle_call({:start_mdns_server, ifname}, _from, state) do
     with {:ok, server_pid} <-
-           MdnsLite.Server.start({ifname, state.mdns_config, state.mdns_services}) do
+           MdnsLite.Responder.start({ifname, state.mdns_config, state.mdns_services}) do
       _ = Logger.debug("Start mdns server: server_pid #{inspect(server_pid)}")
       new_ifname_server_map = Map.put(state.ifname_server_map, ifname, server_pid)
       {:reply, :ok, %State{state | ifname_server_map: new_ifname_server_map}}
@@ -111,7 +111,7 @@ defmodule MdnsLite do
           state.ifname_server_map
 
         pid ->
-          MdnsLite.Server.stop_server(pid)
+          MdnsLite.Responder.stop_server(pid)
           Map.delete(state.ifname_server_map, ifname)
       end
 

--- a/lib/mdns_lite/responder.ex
+++ b/lib/mdns_lite/responder.ex
@@ -1,4 +1,4 @@
-defmodule MdnsLite.Server do
+defmodule MdnsLite.Responder do
   @moduledoc """
   A GenServer that is responsible for responding to a limited number of mDNS
   requests (queries). A UDP port is opened on the mDNS reserved IP/port. Any

--- a/test/mdns_lite/query_test.exs
+++ b/test/mdns_lite/query_test.exs
@@ -6,7 +6,7 @@ defmodule MdnsLite.QueryTest do
   doctest MdnsLite.Query
 
   defp test_state() do
-    %MdnsLite.Server.State{
+    %MdnsLite.Responder.State{
       dot_local_name: 'nerves-21a5.local',
       ifname: "eth0",
       ip: {192, 168, 9, 57},


### PR DESCRIPTION
This is part of a refactor to clarify which GenServers are responsible
for what.