### PR TITLE
Make the IP address monitor configurable to fix tests

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -32,6 +32,12 @@ config :mdns_lite,
     }
   ]
 
+if Mix.env() == :test do
+  # Disable the IP address monitor for mdns_lite unit tests (this is a no-op)
+  config :mdns_lite,
+    ip_address_monitor: {Agent, fn -> nil end}
+end
+
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this
 # file won't be loaded nor affect the parent project. For this reason,

--- a/lib/mdns_lite/application.ex
+++ b/lib/mdns_lite/application.ex
@@ -16,10 +16,17 @@ defmodule MdnsLite.Application do
     def init(_init_arg) do
       excluded_ifnames = Application.get_env(:mdns_lite, :excluded_ifnames, ["lo0", "lo"])
 
+      ip_address_monitor =
+        Application.get_env(
+          :mdns_lite,
+          :ip_address_monitor,
+          {MdnsLite.InetMonitor, excluded_ifnames: excluded_ifnames}
+        )
+
       children = [
         {Registry, keys: :unique, name: MdnsLite.ResponderRegistry},
         {MdnsLite.ResponderSupervisor, []},
-        {MdnsLite.InetMonitor, excluded_ifnames: excluded_ifnames}
+        ip_address_monitor
       ]
 
       Supervisor.init(children, strategy: :one_for_all)


### PR DESCRIPTION
This replaces the IP address monitor with a no-op so that the unit tests
can be run without automatically registering IP addresses. This removes
a lot of eaddrinuse exceptions on my mac.