### PR TITLE
Default values for services

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -9,26 +9,20 @@ config :mdns_lite,
     host: :hostname,
     ttl: 120
   },
+  # A list of this host's services. NB: There are two other mDNS values: weight
+  # and priority that both default to zero unless included in the service below.
   services: [
-    # service type: _http._tcp - used in match
     %{
-      type: "_http._tcp",
       name: "Web Server",
       protocol: "http",
       transport: "tcp",
-      port: 80,
-      weight: 0,
-      priority: 0
+      port: 80
     },
-    # TODO: service_type: _ssh._tcp
     %{
-      type: "_ssh._tcp",
       name: "Secure Socket",
       protocol: "ssh",
       transport: "tcp",
-      port: 22,
-      weight: 0,
-      priority: 0
+      port: 22
     }
   ]
 

--- a/lib/mdns_lite/inet_monitor.ex
+++ b/lib/mdns_lite/inet_monitor.ex
@@ -1,6 +1,8 @@
 defmodule MdnsLite.InetMonitor do
   use GenServer
 
+  require Logger
+
   alias MdnsLite.{Responder, ResponderSupervisor}
 
   @scan_interval 10000
@@ -55,10 +57,10 @@ defmodule MdnsLite.InetMonitor do
     removed_ips = state.ip_list -- new_ip_list
     added_ips = new_ip_list -- state.ip_list
 
-    IO.puts("Removed #{inspect(removed_ips)}")
+    _ = Logger.debug("inet_monitor - removed: #{inspect(removed_ips)}")
     Enum.each(removed_ips, fn {_ifname, addr} -> Responder.stop_server(addr) end)
 
-    IO.puts("Added #{inspect(added_ips)}")
+    _ = Logger.debug("inet_monitor - added: #{inspect(added_ips)}")
     Enum.each(added_ips, fn {_ifname, addr} -> ResponderSupervisor.start_child(addr) end)
 
     %State{state | ip_list: new_ip_list}


### PR DESCRIPTION
Unless specified in the configuration for a service, the values for 
weight and priority default to zero. Also, the so-called service type is 
constructed during initialization.