### PR TITLE
Remove logging for unhandled requests

### DIFF
--- a/lib/mdns_lite/inet_monitor.ex
+++ b/lib/mdns_lite/inet_monitor.ex
@@ -56,10 +56,7 @@ defmodule MdnsLite.InetMonitor do
     removed_ips = state.ip_list -- new_ip_list
     added_ips = new_ip_list -- state.ip_list
 
-    _ = Logger.debug("inet_monitor - removed: #{inspect(removed_ips)}")
     Enum.each(removed_ips, fn {_ifname, addr} -> Responder.stop_server(addr) end)
-
-    _ = Logger.debug("inet_monitor - added: #{inspect(added_ips)}")
     Enum.each(added_ips, fn {_ifname, addr} -> ResponderSupervisor.start_child(addr) end)
 
     %State{state | ip_list: new_ip_list}

--- a/lib/mdns_lite/query.ex
+++ b/lib/mdns_lite/query.ex
@@ -16,10 +16,10 @@ defmodule MdnsLite.Query do
   # An "A" type query. Address mapping record. Return the IP address if
   # this host name matches the query domain.
   def handle(%DNS.Query{class: :in, type: :a, domain: domain} = _query, state) do
-    _ = Logger.debug("DNS A RECORD for interface at #{inspect(state.ip)}")
-
     case state.dot_local_name == domain do
       true ->
+        _ = Logger.debug("DNS A RECORD for interface at #{inspect(state.ip)}")
+
         [
           %DNS.Resource{
             class: :in,
@@ -42,9 +42,8 @@ defmodule MdnsLite.Query do
         %DNS.Query{class: :in, type: :ptr, domain: domain} = _query,
         state
       ) do
-    _ = Logger.debug("DNS PTR RECORD for interface at #{inspect(state.ip)}")
     # Convert our IP address so as to be able to match the arpa address
-    # in the query. ARPA address for IP 192.168.0.112 is 112.0.168.192,in-addr.arpa
+    # in the query. ARPA address for IP 192.168.0.112 is 112.0.168.192.in-addr.arpa
     arpa_address =
       state.ip
       |> Tuple.to_list()
@@ -54,6 +53,8 @@ defmodule MdnsLite.Query do
     cond do
       # Only need to match the beginning characters
       String.starts_with?(to_string(domain), arpa_address) ->
+        _ = Logger.debug("DNS PTR RECORD for interface at #{inspect(state.ip)}")
+
         resource_record = %DNS.Resource{
           class: :in,
           type: :ptr,
@@ -64,6 +65,7 @@ defmodule MdnsLite.Query do
         [resource_record]
 
       domain == '_services._dns-sd._udp.local' ->
+        _ = Logger.debug("DNS PTR RECORD for interface at #{inspect(state.ip)} for DNS-SD")
         # services._dns-sd._udp.local. is a special name for
         # "Service Type Enumeration" which is supposed to find all service
         # types on the network. Let them know about ours.
@@ -90,14 +92,13 @@ defmodule MdnsLite.Query do
         %DNS.Query{class: :in, type: :srv, domain: domain} = _query,
         state
       ) do
-    _ = Logger.debug("DNS SRV RECORD for interface at #{inspect(state.ip)}")
-
     state.services
     |> Enum.filter(fn service ->
       local_service = service.type <> ".local"
       to_string(domain) == local_service
     end)
     |> Enum.map(fn service ->
+      _ = Logger.debug("DNS SRV RECORD for interface at #{inspect(state.ip)}")
       # construct the data value to be returned
       # Note: The spec - RFC 2782 - specifies that the target/hostname end with a dot.
       target = state.dot_local_name ++ '.'
@@ -113,8 +114,13 @@ defmodule MdnsLite.Query do
   end
 
   # Ignore any other type of query
-  def handle(%DNS.Query{type: type} = _query, state) do
-    _ = Logger.debug("IGNORING #{inspect(type)} DNS RECORD for interface at #{inspect(state.ip)}")
+  def handle(%DNS.Query{class: class, type: type} = _query, state) do
+    _ =
+      Logger.debug(
+        "IGNORING #{inspect(class)} #{inspect(type)} DNS RECORD for interface at #{
+          inspect(state.ip)
+        }"
+      )
 
     []
   end


### PR DESCRIPTION
I'm on a network with regular mDNS queries for other devices and the log messages were filling up the log. This removes many of them. I updated the handling locations so that there were still log messages for sending mDNS responses. 