### PR TITLE
Align with RFC 6763

### DIFF
--- a/lib/mdns_lite/query.ex
+++ b/lib/mdns_lite/query.ex
@@ -9,25 +9,19 @@ defmodule MdnsLite.Query do
   Handle a DNS Query
 
   This function returns a list of DNS Resource Records that should be sent back
-  to the querier. The list is dependent on the query type, e.g., PTR, SRV, etc.
+  to the querier. The list is dependent on the query type: A, PTR, SRV.
   """
   @spec handle(DNS.Query.t(), map()) :: [DNS.Resource.t()]
 
   # An "A" type query. Address mapping record. Return the IP address if
-  # this host name matches the query domain.
+  # this host's local name matches the query domain.
   def handle(%DNS.Query{class: :in, type: :a, domain: domain} = _query, state) do
     case state.dot_local_name == domain do
       true ->
         _ = Logger.debug("DNS A RECORD for interface at #{inspect(state.ip)}")
 
         [
-          %DNS.Resource{
-            class: :in,
-            type: :a,
-            ttl: state.ttl,
-            domain: state.dot_local_name,
-            data: state.ip
-          }
+          dns_resource(:a, state.dot_local_name, state.ttl, state.ip)
         ]
 
       _ ->
@@ -35,9 +29,11 @@ defmodule MdnsLite.Query do
     end
   end
 
-  # A "PTR" type query. Reverse address lookup. Return the hostname of an
-  # IP address and a "special" case that recognizes a special domain
-  # "_services._dns-sd._udp.local" - DNS-SD
+  # A "PTR" type query. Thre are three different responses depending on the
+  # domain value of the query:
+  # 1. Reverse address lookup. Return the hostname of an IP address,
+  # 2. A "special" domain value of "_services._dns-sd._udp.local" - DNS-SD
+  # 3. A "service domain, e.g., "foobar.local._ssh._tcp.local"
   def handle(
         %DNS.Query{class: :in, type: :ptr, domain: domain} = _query,
         state
@@ -51,65 +47,76 @@ defmodule MdnsLite.Query do
       |> Enum.join(".")
 
     cond do
-      # Only need to match the beginning characters
-      String.starts_with?(to_string(domain), arpa_address) ->
-        _ = Logger.debug("DNS PTR RECORD for interface at #{inspect(state.ip)}")
-
-        resource_record = %DNS.Resource{
-          class: :in,
-          type: :ptr,
-          ttl: state.ttl,
-          data: state.dot_local_name
-        }
-
-        [resource_record]
-
       domain == '_services._dns-sd._udp.local' ->
         _ = Logger.debug("DNS PTR RECORD for interface at #{inspect(state.ip)} for DNS-SD")
         # services._dns-sd._udp.local. is a special name for
         # "Service Type Enumeration" which is supposed to find all service
         # types on the network. Let them know about ours.
         Configuration.get_mdns_services()
-        |> Enum.map(fn service ->
-          %DNS.Resource{
-            domain: domain,
-            class: :in,
-            type: :ptr,
-            ttl: state.ttl,
-            data: to_charlist(service.type <> ".local")
-          }
+        |> Enum.flat_map(fn service ->
+          [
+            dns_resource(:ptr, domain, state.ttl, to_charlist(service.type <> ".local"))
+          ]
         end)
+
+      # Something is looking for a specific service. Can we offer this service?
+      String.starts_with?(to_string(domain), "_") ->
+        Configuration.get_mdns_services()
+        |> Enum.filter(fn service ->
+          to_string(domain) == service.type <> ".local"
+        end)
+        |> Enum.flat_map(fn service ->
+          service_instance_name =
+            String.to_charlist("#{state.instance_name}.#{service.type}.local")
+
+          target = state.dot_local_name ++ '.'
+          srv_data = {service.priority, service.weight, service.port, target}
+
+          [
+            dns_resource(:ptr, domain, state.ttl, service_instance_name),
+            # Until we support the user specification of TXT values,
+            # the RFC says at a minimum return a TXT record with an empty string
+            dns_resource(:txt, service_instance_name, state.ttl, [""]),
+            dns_resource(:srv, service_instance_name, state.ttl, srv_data),
+            dns_resource(:a, state.dot_local_name, state.ttl, state.ip)
+          ]
+        end)
+
+      # Reverse domain lookup. Only need to match the beginning characters
+      String.starts_with?(to_string(domain), arpa_address) ->
+        full_arpa_address = to_charlist(arpa_address <> ".in-addr.arpa.")
+
+        [dns_resource(:ptr, full_arpa_address, state.ttl, state.dot_local_name)]
 
       true ->
         []
     end
   end
 
-  # A "SRV" type query. Find services, e.g., HTTP, SSH. The domain field in a
-  # SRV service query will look like "_http._tcp.local". Respond only on an exact
-  # match
+  # An "SRV" type query. Find services, e.g., HTTP, SSH. The domain field in a
+  # SRV service query will look like, for example, "<host name>._http._tcp.local".
+  # Respond only on an exact # match
   def handle(
         %DNS.Query{class: :in, type: :srv, domain: domain} = _query,
         state
       ) do
     state.services
     |> Enum.filter(fn service ->
-      local_service = service.type <> ".local"
-      to_string(domain) == local_service
+      instance_service_name = "#{state.instance_name}.#{service.type}.local"
+      to_string(domain) == instance_service_name
     end)
-    |> Enum.map(fn service ->
-      _ = Logger.debug("DNS SRV RECORD for interface at #{inspect(state.ip)}")
+    |> Enum.flat_map(fn service ->
       # construct the data value to be returned
       # Note: The spec - RFC 2782 - specifies that the target/hostname end with a dot.
-      target = state.dot_local_name ++ '.'
-      data = {service.priority, service.weight, service.port, target}
+      service_instance_name = String.to_charlist("#{state.instance_name}.#{service.type}.local")
 
-      %DNS.Resource{
-        class: :in,
-        type: :srv,
-        ttl: state.ttl,
-        data: data
-      }
+      target = state.dot_local_name ++ '.'
+      srv_data = {service.priority, service.weight, service.port, target}
+
+      [
+        dns_resource(:srv, service_instance_name, state.ttl, srv_data),
+        dns_resource(:a, state.dot_local_name, state.ttl, state.ip)
+      ]
     end)
   end
 
@@ -123,5 +130,15 @@ defmodule MdnsLite.Query do
       )
 
     []
+  end
+
+  defp dns_resource(type, domain, ttl, data) do
+    %DNS.Resource{
+      domain: domain,
+      class: :in,
+      type: type,
+      ttl: ttl,
+      data: data
+    }
   end
 end

--- a/lib/mdns_lite/responder.ex
+++ b/lib/mdns_lite/responder.ex
@@ -31,6 +31,8 @@ defmodule MdnsLite.Responder do
     @moduledoc false
     @type t() :: struct()
     defstruct services: [],
+              # RFC 6763 nomenclature, aka hostname
+              instance_name: "",
               # Note: Erlang string
               dot_local_name: '',
               ttl: 120,
@@ -66,8 +68,8 @@ defmodule MdnsLite.Responder do
     # Retrieve some configuration values
     mdns_config = Configuration.get_mdns_config()
     mdns_services = Configuration.get_mdns_services()
-    discovery_name = resolve_mdns_name(mdns_config.host)
-    dot_local_name = discovery_name <> ".local"
+    instance_name = resolve_mdns_name(mdns_config.host)
+    dot_local_name = instance_name <> ".local"
     # Join the mDNS multicast group
 
     {:ok,
@@ -76,6 +78,7 @@ defmodule MdnsLite.Responder do
        services: mdns_services,
        ip: address,
        ttl: mdns_config.ttl,
+       instance_name: instance_name,
        dot_local_name: to_charlist(dot_local_name)
      }, {:continue, :initialization}}
   end

--- a/test/mdns_lite/query_test.exs
+++ b/test/mdns_lite/query_test.exs
@@ -54,8 +54,14 @@ defmodule MdnsLite.QueryTest do
     assert Query.handle(query, test_state()) == result
   end
 
+  test "ignores A request for someone else" do
+    query = %DNS.Query{class: :in, domain: 'someone-else.local', type: :a}
+
+    assert Query.handle(query, test_state()) == []
+  end
+
   test "responds to a PTR request" do
-    query = %DNS.Query{class: :in, domain: '57.9.168.192.in-addr.arpa', type: :ptr}
+    query = %DNS.Query{class: :in, domain: '57.9.168.192', type: :ptr}
 
     result = [
       %DNS.Resource{
@@ -63,6 +69,7 @@ defmodule MdnsLite.QueryTest do
         class: :in,
         cnt: 0,
         data: test_state().dot_local_name,
+        domain: '57.9.168.192.in-addr.arpa.',
         func: false,
         tm: :undefined,
         ttl: 120,
@@ -93,7 +100,7 @@ defmodule MdnsLite.QueryTest do
   end
 
   test "responds to an SRV request for a known service" do
-    known_service = "_http._tcp.local"
+    known_service = "nerves-21a5.local._http._tcp.local"
     query = %DNS.Query{class: :in, domain: to_charlist(known_service), type: :srv}
 
     result =
@@ -121,9 +128,9 @@ defmodule MdnsLite.QueryTest do
     assert Query.handle(query, test_state()) == result
   end
 
-  test "ignores A request for someone else" do
-    query = %DNS.Query{class: :in, domain: 'someone-else.local', type: :a}
-
+  test "ignore SRV request without the host (instance) name" do
+    service_only = "_http._tcp.local"
+    query = %DNS.Query{class: :in, domain: to_charlist(service_only), type: :srv}
     assert Query.handle(query, test_state()) == []
   end
 end


### PR DESCRIPTION
This PR addresses Issue #31 

Bring `mdns_lite` into conformance with RFC 6763 - DNS Service-based discovery. SRV and PTR queries are now responded to correctly.

A PTR response is dependent on the domain argument. If all services are asked for, respond with multiple PTR records. If the request is for a particular service, respond with PTR, TXT, and A records for that service. If request is a reverse domain lookup, respond with a PTR record.

An SRV request for a host's service responds with  SRV and  A records. 
