### PR TITLE
Issue-32 - Multiple host names

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ services in the Configuration section below.
 MdnsLite employs a network interface monitor that can dynamically adjust to
 network changes, e.g., assignment of a new IP address to a host. The current
 version of MdnsLite comes with an `InetMonitor` which periodically checks via `inet:getifaddrs()`
-for changes in the network. For exmaple, a change could be the re-assignment of IP addresses.
+for changes in the network. For exmaple, a change could be the re-assignment of IP addresses. For configuration values related to the interface monitor, please see the Confgiration section below.
 
 MdnsLite recognizes the following [query types](https://en.wikipedia.org/wiki/List_of_DNS_record_types):
 
@@ -65,11 +65,14 @@ config :mdns_lite,
 
 (Note that the configuration changed from v0.2 to v0.3, eliminating a superflous map.)
 
-The `host` and `ttl` are values that will be used in the
-construction of mDNS (DNS) responses. `host` can have the value of  `:hostname` in which case the value will be
-replaced with the value of `:inet.gethostname()`, otherwise you can provide a
-string value. `ttl` refers to a Time To Live value in seconds. [RFC 6762 - Multicast
+The `host` and `ttl` are values that will be used in the construction of mDNS (DNS) responses. 
+
+`host` can have the value of  `:hostname` in which case the value will be replaced with the value of `:inet.gethostname()`, otherwise you can provide a string value. You can specify an alias hostname in which case `host` will be `["hostname", "alias-example"]`. The second value must be a string. When you use an alias, an "A" query can be made to  `alias-example.local` as well as to `hostname.local`.
+
+`ttl` refers to a Time To Live value in seconds. [RFC 6762 - Multicast
 DNS](https://tools.ietf.org/html/rfc6762) - recommends a default value of 120 seconds.
+
+As mentioned above, `MdnsLite` uses an interface monitor. `InetMonitor` is currently the only monitor available. The configuration value `ip_address_monitor` (not shown) defaults to `Mdns.InetMonitor. And the configuration value `excluded_ifnames` represents those interfaces that the `InetMonitor` will **not** watch. Its default value is ["lo0", "lo"].
 
 The `services` section lists the services that the host offers,
 such as providing an HTTP server. You must supply the `protocol`, `transport` and

--- a/config/config.exs
+++ b/config/config.exs
@@ -5,8 +5,12 @@ use Mix.Config
 config :mdns_lite,
   # Use these values to construct the DNS resource record responses
   # to a DNS query.
+  # host can be one of the values: hostname1, [hostname1], or [hostname1, hostname2]
+  # where hostname1 is the atom :hostname in which case it is replaced with the
+  # value of :int.gethostname() or a string and hostname2 is a string value.
+  # Exmple: [:hostname, "nerves"]
 
-  host: :hostname,
+  host: [:hostname, "nerves"],
   ttl: 120,
 
   # A list of this host's services. NB: There are two other mDNS values: weight

--- a/mix.exs
+++ b/mix.exs
@@ -1,13 +1,13 @@
 defmodule MdnsLite.MixProject do
   use Mix.Project
 
-  @version "0.3.0"
+  @version "0.4.0"
 
   def project do
     [
       app: :mdns_lite,
       version: @version,
-      elixir: "~> 1.8",
+      elixir: "~> 1.9",
       build_embedded: true,
       start_permanent: Mix.env() == :prod,
       docs: docs(),

--- a/test/mdns_lite/query_test.exs
+++ b/test/mdns_lite/query_test.exs
@@ -8,6 +8,7 @@ defmodule MdnsLite.QueryTest do
   defp test_state() do
     %MdnsLite.Responder.State{
       dot_local_name: 'nerves-21a5.local',
+      dot_alias_name: nil,
       ip: {192, 168, 9, 57},
       services: [
         %{
@@ -34,6 +35,11 @@ defmodule MdnsLite.QueryTest do
     }
   end
 
+  defp test_alias_state() do
+    test_state = test_state()
+    %MdnsLite.Responder.State{test_state | dot_alias_name: 'nerves.local'}
+  end
+
   test "responds to an A request" do
     query = %DNS.Query{class: :in, domain: 'nerves-21a5.local', type: :a}
 
@@ -52,6 +58,26 @@ defmodule MdnsLite.QueryTest do
     ]
 
     assert Query.handle(query, test_state()) == result
+  end
+
+  test "responds to an A request for the alias" do
+    query = %DNS.Query{class: :in, domain: 'nerves.local', type: :a}
+
+    result = [
+      %DNS.Resource{
+        bm: [],
+        class: :in,
+        cnt: 0,
+        data: {192, 168, 9, 57},
+        domain: 'nerves.local',
+        func: false,
+        tm: :undefined,
+        ttl: 120,
+        type: :a
+      }
+    ]
+
+    assert Query.handle(query, test_alias_state()) == result
   end
 
   test "ignores A request for someone else" do


### PR DESCRIPTION
Provide support for an "alias" host name. If the configuration value of :host is  ["nerves-7fcb", "nerves""] then an "A" DNS query will answer to "nerves-7fb.local" and "nerves.local".

A test for the above was added.

Documentation and comments were updated.