### PR TITLE
Remove logging on ignored queries

### DIFF
--- a/lib/mdns_lite/query.ex
+++ b/lib/mdns_lite/query.ex
@@ -124,14 +124,7 @@ defmodule MdnsLite.Query do
   end
 
   # Ignore any other type of query
-  def handle(%DNS.Query{class: class, type: type} = _query, state) do
-    _ =
-      Logger.debug(
-        "IGNORING #{inspect(class)} #{inspect(type)} DNS RECORD for interface at #{
-          inspect(state.ip)
-        }"
-      )
-
+  def handle(_query, _state) do
     []
   end
 


### PR DESCRIPTION
Each network connect, I get about 30 ignored query messages in the log
that all look like this:

```
00:06:20.417 [debug] IGNORING :in :any DNS RECORD for interface at {192, 168, 0, 1}
```

The log message does not seem helpful without more information and since
the non-Elixir mdns responders I've used don't log the queries they
ignore, I removed it.