### PR TITLE
Allow updating InetMonitor addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ services in the Configuration section below.
 MdnsLite employs a network interface monitor that can dynamically adjust to
 network changes, e.g., assignment of a new IP address to a host. The current
 version of MdnsLite comes with an `InetMonitor` which periodically checks via `inet:getifaddrs()`
-for changes in the network. For example, a change could be the re-assignment of IP addresses. For configuration values related to the interface monitor, please see the Configuration section below.
+for changes in the network. For example, a change could be the re-assignment of IP addresses.
+You can also update `InetMonitor` manually through the API via `InetMonitor.add/1` and
+`InetMonitor.remove/1`. This is useful if your networking supplies notifications for events and
+you want to supply the changes without needing a new monitor. For configuration values related
+to the interface monitor, please see the Configuration section below.
 
 MdnsLite recognizes the following [query types](https://en.wikipedia.org/wiki/List_of_DNS_record_types):
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -31,9 +31,9 @@ config :mdns_lite,
   ]
 
 if Mix.env() == :test do
-  # Disable the IP address monitor for mdns_lite unit tests (this is a no-op)
+  # Disable UDP subscription, but allow responders to start for tests
   config :mdns_lite,
-    ip_address_monitor: {Agent, fn -> nil end}
+    active_responders: false
 end
 
 # This configuration is loaded before any dependency and is restricted

--- a/lib/mdns_lite/responder.ex
+++ b/lib/mdns_lite/responder.ex
@@ -30,7 +30,8 @@ defmodule MdnsLite.Responder do
               dot_alias_name: '',
               ttl: 120,
               ip: {0, 0, 0, 0},
-              udp: nil
+              udp: nil,
+              active: true
   end
 
   ##############################################################################
@@ -77,11 +78,17 @@ defmodule MdnsLite.Responder do
        ttl: mdns_config.ttl,
        instance_name: instance_name,
        dot_local_name: to_charlist(dot_local_name),
-       dot_alias_name: to_charlist(dot_alias_name)
+       dot_alias_name: to_charlist(dot_alias_name),
+       active: Application.get_env(:mdns_lite, :active_responders, true)
      }, {:continue, :initialization}}
   end
 
   @impl true
+  def handle_continue(:initialization, %{active: false} = state) do
+    # Used only for testing.
+    {:noreply, state}
+  end
+
   def handle_continue(:initialization, state) do
     {:ok, udp} = :gen_udp.open(@mdns_port, udp_options(state.ip))
 

--- a/lib/mdns_lite/utilities.ex
+++ b/lib/mdns_lite/utilities.ex
@@ -28,4 +28,29 @@ defmodule MdnsLite.Utilities do
   @spec ip_family(:inet.ip_address()) :: :inet | :inet6
   def ip_family({_, _, _, _}), do: :inet
   def ip_family({_, _, _, _, _, _, _, _}), do: :inet6
+
+  @doc """
+  Convert a value to an :inet.ip_address()
+  """
+  @spec to_ip(any) :: :inet.ip_address() | :bad_ip
+  def to_ip(ip) when is_tuple(ip) do
+    case :inet.ntoa(ip) do
+      {:error, _} -> :bad_ip
+      ip_char -> to_ip(ip_char)
+    end
+  end
+
+  def to_ip(ip) when is_list(ip) do
+    case :inet.parse_strict_address(ip) do
+      {:ok, ip} -> ip
+      _ -> :bad_ip
+    end
+  end
+
+  def to_ip(ip_str) when is_bitstring(ip_str) do
+    to_charlist(ip_str)
+    |> to_ip()
+  end
+
+  def to_ip(_), do: :bad_ip
 end

--- a/test/mdns_lite/inet_monitor_test.exs
+++ b/test/mdns_lite/inet_monitor_test.exs
@@ -1,0 +1,27 @@
+defmodule MdnsLite.InetMonitorTest do
+  use ExUnit.Case, async: true
+
+  alias MdnsLite.{InetMonitor, ResponderSupervisor}
+
+  test "can add and remove IP for monitor" do
+    new_ip = {'wlan0', {127, 0, 0, 2}}
+
+    responders = Supervisor.count_children(ResponderSupervisor).specs
+
+    :ok = InetMonitor.add(new_ip)
+
+    assert new_ip in :sys.get_state(InetMonitor).ip_list
+    assert Supervisor.count_children(ResponderSupervisor).active == responders + 1
+
+    # remove the IP address
+    :ok = InetMonitor.remove(new_ip)
+
+    assert new_ip not in :sys.get_state(InetMonitor).ip_list
+  end
+
+  test "cannot add with bad ip_list" do
+    bad = [{'wlan', :wat}]
+
+    assert InetMonitor.add(bad) == {:error, :invalid_ip}
+  end
+end

--- a/test/mdns_lite/utilities_test.exs
+++ b/test/mdns_lite/utilities_test.exs
@@ -107,4 +107,31 @@ defmodule MdnsLite.UtilitiesTest do
     assert Utilities.ip_family({192, 168, 9, 213}) == :inet
     assert Utilities.ip_family({65152, 0, 0, 0, 3177, 34598, 19643, 57597}) == :inet6
   end
+
+  test "to_ip" do
+    bad =
+      [
+        {1, 2},
+        "192.a.b.1",
+        :wat,
+        {1, 2, "4", 4},
+        {1, 2, "4", 4, 5, 6},
+        10
+      ]
+      |> Enum.map(&Utilities.to_ip/1)
+
+    good =
+      [
+        {192, 168, 0, 1},
+        "192.168.0.1",
+        '192.168.0.1',
+        {64768, 48059, 0, 0, 0, 0, 0, 10},
+        'fd00:bbbb::a',
+        "fd00:bbbb::a"
+      ]
+      |> Enum.map(&Utilities.to_ip/1)
+
+    assert Enum.all?(bad, &(&1 == :bad_ip))
+    assert Enum.all?(good, &is_tuple/1)
+  end
 end


### PR DESCRIPTION
Adds `add/1` and `remove/1` to InetMonitor to allow updating IP Addresses manually.

This will specifically be useful in combination with `VintageNet.subscribe` to update IP address monitoring from network notification events.

Also changes how we run Responders so that we can use them with `InetMonitor` tests