### PR TITLE
Handle nil from VintageNet reports

### DIFF
--- a/lib/mdns_lite/vintage_net_monitor.ex
+++ b/lib/mdns_lite/vintage_net_monitor.ex
@@ -60,6 +60,8 @@ defmodule MdnsLite.VintageNetMonitor do
     {:noreply, new_state}
   end
 
+  defp add_ips(state, nil), do: state
+
   defp add_ips(%{ip_list: ip_list} = state, address_data) do
     ip_list =
       fetch_ips(address_data)
@@ -89,6 +91,8 @@ defmodule MdnsLite.VintageNetMonitor do
   defp filter_by_ipv4(ip_list, true) do
     Enum.filter(ip_list, &(MdnsLite.Utilities.ip_family(&1) == :inet))
   end
+
+  defp remove_ips(state, nil), do: state
 
   defp remove_ips(%{ip_list: ip_list} = state, address_data) do
     ip_list =


### PR DESCRIPTION
These are generated on the first and last reports when properties come
into existence or go away. This fixes the following crash:

```
[error] GenServer MdnsLite.VintageNetMonitor terminating
** (Protocol.UndefinedError) protocol Enumerable not implemented for nil of type Atom. This protocol is implemented for the following type(s): HashSet, Range, Map, Function, List, Stream, Date.Range, HashDict, GenEvent.Stream, MapSet, File.Stream, IO.Stream
    (elixir) lib/enum.ex:1: Enumerable.impl_for!/1
    (elixir) lib/enum.ex:141: Enumerable.reduce/3
    (elixir) lib/enum.ex:3023: Enum.map/2
    (mdns_lite) lib/mdns_lite/vintage_net_monitor.ex:95: MdnsLite.VintageNetMonitor.remove_ips/2
    (mdns_lite) lib/mdns_lite/vintage_net_monitor.ex:54: MdnsLite.VintageNetMonitor.handle_info/2
    (stdlib) gen_server.erl:637: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:711: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```