### PR TITLE
Fix crash when handling undecodable mDNS messages

### DIFF
--- a/lib/mdns_lite/responder.ex
+++ b/lib/mdns_lite/responder.ex
@@ -112,19 +112,20 @@ defmodule MdnsLite.Responder do
   @impl true
   def handle_info({:udp, _socket, src_ip, src_port, packet}, state) do
     # Decode the UDP packet
-    dns_record = DNS.Record.decode(packet)
-    # qr is the query/response flag; false (0) = query, true (1) = response
-    if !dns_record.header.qr && length(dns_record.qdlist) > 0 do
+    with {:ok, dns_record} <- :inet_dns.decode(packet),
+         dns = DNS.Record.from_record(dns_record),
+         # qr is the query/response flag; false (0) = query, true (1) = response
+         0 <- dns.header.qr do
       # There can be multiple queries in each request
-      dns_record.qdlist
+      dns.qdlist
       |> Enum.map(fn qd -> {qd.class, Query.handle(qd, state)} end)
       |> Enum.each(fn
         # Erlang doesn't know about unicast class
         {32769, resources} ->
-          send_response(resources, dns_record, {src_ip, src_port}, state)
+          send_response(resources, dns, {src_ip, src_port}, state)
 
         {_, resources} ->
-          send_response(resources, dns_record, mdns_destination(src_ip, src_port), state)
+          send_response(resources, dns, mdns_destination(src_ip, src_port), state)
       end)
     end
 


### PR DESCRIPTION
This fixes the following crash:

```
22:28:35.991 [error] GenServer {MdnsLite.ResponderRegistry, {192, 168, 8, 49}} terminating
** (MatchError) no match of right hand side value: {:error, :fmt}
    (dns) lib/dns/record.ex:47: DNS.Record.decode/1
    (mdns_lite) lib/mdns_lite/responder.ex:115: MdnsLite.Responder.handle_info/2
    (stdlib) gen_server.erl:637: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:711: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message: {:udp, #Port<0.575>, {192, 168, 1, 141}, 47496, <<10, 186, 16, 0>>}
State: %MdnsLite.Responder.State{dot_alias_name: [], dot_local_name: 'nerves.local', instance_name: "nerves", ip: {192, 168, 8, 49}, services: [], skip_udp: nil, ttl: 120, udp: #Port<0.575>}
```

The fix changes the behavior from crashing to silently ignoring
undecodable packets. It seems that there's just junk floating around on
networks. Crashing ended up causing a lot of noise in logs and almost
certainly enables a DoS attack on the supervision tree and the mdns_lite
OTP application.